### PR TITLE
Make the mod less likely to conflict with other mods

### DIFF
--- a/behaviors/npc/villageguard.behavior.patch
+++ b/behaviors/npc/villageguard.behavior.patch
@@ -1,6 +1,12 @@
 [
   {
-    "op": "remove",
-    "path": "/root/children/1"
+    "op": "replace",
+    "path": "/root/children/1",
+    "value": {
+      "title": "no-op",
+      "type": "action",
+      "name": "failure",
+      "parameters": {}
+    }
   }
 ]

--- a/behaviors/npc/villager.behavior.patch
+++ b/behaviors/npc/villager.behavior.patch
@@ -1,6 +1,12 @@
 [
   {
-    "op": "remove",
-    "path": "/root/children/2"
+    "op": "replace",
+    "path": "/root/children/2",
+    "value": {
+      "title": "no-op",
+      "type": "action",
+      "name": "failure",
+      "parameters": {}
+    }
   }
 ]


### PR DESCRIPTION
The current implementation gets rid of the stealing penalty, but it does so in an unsafe way. By removing a node from a behavior tree, you change the index of every subsequent node, making conflicts with other mods that change this tree likely. If, instead, you replace the node with a no-op action, the subsequent nodes' indices will be unaffected, and a conflict would only happen if another mod tried to alter this exact node.

I've updated your mod to replace the "attackthief" and "accuse" nodes with the "failure" action, which in the context of a dynamic composite parent is equivalent to a no-op.